### PR TITLE
4-YIM2UL2ET

### DIFF
--- a/YIM2UL2ET/README.md
+++ b/YIM2UL2ET/README.md
@@ -4,5 +4,6 @@
 |:----:|:---------:|:----:|:-----:|:----:|
 | 1차시 | 2024.02.12 |  그리디  | [BOJ 18310](https://www.acmicpc.net/problem/18310)  | [BOJ 18310 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/3) |
 | 2차시 | 2024.02.15 |  그리디  | [BOJ 1263](https://www.acmicpc.net/problem/1263)  | [BOJ 1449 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/7) |
-| 3차시 | 2024.02.18 |  자료구조  | [BOJ 2504](https://www.acmicpc.net/problem/2504)  | [BOJ 2504 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/9) |
+| 3차시 | 2024.02.18 |  스택  | [BOJ 2504](https://www.acmicpc.net/problem/2504)  | [BOJ 2504 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/9) |
+| 4차시 | 2024.02.21 |  덱  | [BOJ 1021](https://www.acmicpc.net/problem/1021)  | [BOJ 1021 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/12) |
 ---

--- a/YIM2UL2ET/덱/4차시 - BOJ 1021.cpp
+++ b/YIM2UL2ET/덱/4차시 - BOJ 1021.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <algorithm>
+#include <deque>
+
+int main(void)
+{
+    int n, m, k, idx, result;
+    std::deque <int> dq;
+
+    std::cin >> n >> m;
+    for (int i = 0; i < n;) {
+        dq.push_back(++i);
+    }
+
+    result = 0;
+    for (int i = 0; i < m; i++) {
+        std::cin >> k;
+
+        std::deque <int> :: iterator iter;
+        iter = std::find(dq.begin(), dq.end(), k);
+        idx = std::distance(dq.begin(), iter);
+
+        if (idx < dq.size() - idx) {
+            result += idx;
+            for (int j = 0; j < idx; j++) {
+                int temp = dq.front();
+                dq.pop_front();
+                dq.push_back(temp);
+            }
+        }
+        else {
+            result += dq.size() - idx;
+            for (int j = 0; j < dq.size() - idx; j++) {
+                int temp = dq.back();
+                dq.pop_back();
+                dq.push_front(temp);
+            }
+        }
+
+        dq.pop_front();
+    }
+    
+    std::cout << result;
+    return 0;   
+}


### PR DESCRIPTION
## 🔗 문제 링크
[1021 - 회전하는 큐](https://www.acmicpc.net/problem/1021)

## ✔️ 소요된 시간
30m + α

## ✨ 수도 코드

### 1. 문제 설명
이 문제는 1부터 `n`까지의 숫자 원소를 가지고 있는 `queue`에서 `m`개의 수를 차례대로 입력 받아 3가지 연산을 이용하여 순서대로 `queue`에서 빼내고, 그중에서 2번, 3번의 연산 횟수의 최솟값을 구하는 문제입니다. 다음은 큐의 초기 상태와 각 3가지 연산입니다.

![KakaoTalk_20240221_232928020_01](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/ae6db10c-6cff-4b9f-99d8-b062d0a0ca57)

초기 큐의 상태는 이렇습니다.

![KakaoTalk_20240221_232928020_02](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/0ca391c7-29ae-4ef7-8578-b0d18471f4ff)

1번 연산은 첫번째로 가리키는 원소를 빼내는 연산입니다.

![KakaoTalk_20240221_232928020_03](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/03687477-044a-417a-b69a-d028855dd59c)

2번 연산은 첫번째로 가리키는 원소를 왼쪽으로 한칸씩 옮기는 연산입니다.

![KakaoTalk_20240221_232928020_04](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/c28fe0a0-433d-4f64-84dc-a712975ccc8b)

3번 연산은 첫번째로 가리키는 원소를 오른쪽으로 한칸씩 옮기는 연산입니다.

### 2. 문제 분석

#### 1. 큐를 이용한 연산 구현 시도

보자마자 바로 원형 큐가 생각나시죠? 하지만 조금은 다릅니다. 
우선 그림을 보면서 3가지 연산에 대한 구현을 생각을 해봅시다. (코드 구현은 나중에)

1번 연산은 queue에서 첫번째로 가리키는 원소를 빼는 작업입니다. 
![KakaoTalk_20240221_232928020_05](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/8e82bcec-7bfe-4409-9edc-6f3e28e40f65)

간단하게 첫번째 원소를 `pop`해주면 되겠지요.

2번 연산은 `queue`에서 원소들을 한칸씩 왼쪽으로 옮기는 작업입니다.
![KakaoTalk_20240221_232928020_06](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/d1f73dd1-7d0d-4ee8-8d04-5bd892dc0a3c)

우리는 큐를 쓰기 때문에 `queue`에서 첫번째 원소를 뒤쪽으로 옮겨주면 되겠지요?
간단하게 맨 앞에 있는 원소를 임시 변수에 저장해 둔 후에  `pop` 하고, 이를 다시 뒤에서 `push`하면 됩니다. 

3번 연산은 `queue`에서 원소들을 한칸씩 오른쪽으로 옮기는 작업입니다.
![KakaoTalk_20240221_232928020_07](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/a5a89194-f382-44cc-9d48-a9a5f8156433)

이 때는 2번 연산처럼 맨 뒤에 있는 원소를 임시 변수에 저장해 둔 후에 `pop` 하고, 이를 앞에서 `push` 해야 합니다.

그러나 여기서 문제가 생깁니다. 큐에서는 `push`를 뒤쪽에만 할 수 있고, `pop`은 앞쪽에서만 가능하기 때문입니다.
따라서 이 문제는 큐를 써야 할 것이 아니라 덱을 사용하여 앞과 뒤 양쪽에서 값을 `pop` 하고 `push`할 수 있도록 해야 합니다.

#### 2. 덱을 이용한 연산 구현
그렇다면 덱을 이용하여 3가지 연산을 코드로 구현해 보도록 하겠습니다. 
`dq`는 임의로 1 ~ `n`까지 숫자를 차례대로 원소로 가지고 있다고 가정합시다.

```cpp
int temp;
std::deque <int> dq(n); 

// 1번 연산
dq.pop_front();

// 2번 연산
temp = dq.front();
dq.pop_front();
dq.push_back(temp);

// 3번 연산
int temp = dq.back();
dq.pop_back();
dq.push_front(temp);
```

큐가 아닌 덱을 사용하면 1번과 2번 연산은 물론이고 3번 연산까지도 깔끔하게 구현 할 수 있음을 확인할 수 있습니다.

#### 3. `result`값 구하기
그럼 이제 문제의 본질로 돌아와 봅시다. 문제가 원하는 값은 2번과 3번 연산을 가능한 최소로 사용한 횟수입니다.

어떻게 구할까 머릿속으로 생각하지 말고 그림을 보고 편하게 생각해봅시다.

![KakaoTalk_20240221_232928020_08](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/f729fa90-5062-492e-a5a1-d3b33e8e162c)

만약 덱의 크기가 `8`이라고 할 때 첫 번째로 가리키는 원소가 `a1`이고, `a7`을 꺼내고 싶으면 어떻게 하면 좋을까요?
2번 연산을 `6`회 사용한 후에 1번 연산을 하는 것과, 3번 연산을 `2`회 사용한 후에 1번 연산을 하는 것이 있겠지요?
또한 `result`값에는 더 작은 값을 더해주어야 하므로 `2`를 더해주어야 할 것입니다.

![KakaoTalk_20240221_232928020_09](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/c6b18dda-0fbf-44e0-982b-7630db0870a0)

이를 선형으로 봐봅시다. 

![KakaoTalk_20240221_232928020_10](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/132066506/9cf9fee8-1804-4601-a730-8837a63ede21)

`a1`과 `a7`의 거리 차는 2번 연산을 활용하면 `6`의 거리를 갖게 되고, 3번 연산을 활용하면 `2`의 거리를 갖게 됩니다.
이 때 각각의 거리 (= 연산 횟수)는 `a7`의 인덱스와 덱의 크기 간의 관계식으로 나타낼 수 있습니다.
이 그림에서는 `2번 연산 횟수` = `a7의 인덱스` 이고, `3번 연산 횟수` = `덱의 크기` - `a7의 인덱스` 로 나타낼 수 있지요.

이를 일반화 하면 꺼내고 싶은 원소의 위치를 `idx`, 덱의 사이즈를 `size`라고 할 때 다음과 같이 정리할 수 있습니다.

| 연산 종류 | 연산 횟수 | 
|:-----------:|:------------:|
| 2번 연산 |  `idx` | 
| 3번 연산 | `size` - `idx` |

이를 총 `m`번의 입력 값에 따라 if문을 활용하여 더 적은 연산 횟수를 구하여 그에 따른 연산 횟수를 `result`값에 더하고, 연산하는 것을 반복해 나가면 될 것입니다. 이제 수도코드를 짜봅시다.

### 3. 수도코드
```
int형 변수 n, m, k, idx, result 선언
int형 덱 dq 선언

n, m 입력받기
for (i = 0 부터 n-1 까지) {
    dq에  i+1을 push
}

result 0으로 초기화

for (i = 0 부터 m-1 까지) {
    k 입력 받기
    idx = k가 값으로 있는 dq의 index
    
    if (idx < dq의 크기 - idx) {
        result += idx
        for (j = 0 부터 idx-1 까지) {
            2번 연산 (맨 앞 원소를 맨 뒤로 옮기기)
        }
    else {
        result += dq의 크기 - idx
        for (j = 0 부터 idx-1 까지) {
            3번 연산 (맨 뒤 원소를 맨 앞으로 옮기기)
        }
    1번 연산 (맨 앞 원소 제거)
}

result 출력
프로그램 종료
```

### 4. 최종 코드

```cpp
#include <iostream>
#include <algorithm>
#include <deque>

int main(void)
{
    int n, m, k, idx, result;
    std::deque <int> dq;

    std::cin >> n >> m;
    for (int i = 0; i < n;) {
        dq.push_back(++i);
    }

    result = 0;
    for (int i = 0; i < m; i++) {
        std::cin >> k;

        std::deque <int> :: iterator iter;
        iter = std::find(dq.begin(), dq.end(), k);
        idx = std::distance(dq.begin(), iter);

        if (idx < dq.size() - idx) {
            result += idx;
            for (int j = 0; j < idx; j++) {
                int temp = dq.front();
                dq.pop_front();
                dq.push_back(temp);
            }
        }
        else {
            result += dq.size() - idx;
            for (int j = 0; j < dq.size() - idx; j++) {
                int temp = dq.back();
                dq.pop_back();
                dq.push_front(temp);
            }
        }

        dq.pop_front();
    }
    
    std::cout << result;
    return 0;   
}
```

## 📚 새롭게 알게된 내용
스택에 이어서 큐를 공부해 보았습니다. 생각하는 과정을 쓰는 것은 여전히 쉽지가 않네요. (문제 푸는데 30분, PR 쓰는데 4시간..)

다음은 도움을 받은 자료들 입니다.
[deque container 정리](https://blockdmask.tistory.com/73)
[find 함수 사용법](https://8156217.tistory.com/21)