### PR TITLE
4-mong3125

### DIFF
--- a/mong3125/DFS/P023_11724.java
+++ b/mong3125/DFS/P023_11724.java
@@ -1,0 +1,63 @@
+package CH05_탐색;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class P023_11724 {
+    static int N, M;
+    static int[][] edges;
+    static int[] cache;
+
+    public static void main(String[] args) throws IOException {
+        // 입력
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        // 노드의 수, 엣지의 수 입력
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        edges = new int[N + 1][N + 1];
+        cache = new int[N + 1];
+
+        // 엣지 입력
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // 양방향 입력
+            edges[a][b] = 1;
+            edges[b][a] = 1;
+        }
+
+        int count = 0;
+        for (int i = 1; i <= N; i++) {
+            if (dfs(i, i)) {
+                count++;
+            }
+        }
+
+        System.out.println(count);
+
+        br.close();
+    }
+
+    public static boolean dfs(int id, int check) {
+        if (cache[id] != 0) return false;
+
+        cache[id] = check;
+
+        for (int i = 1; i <= N; i++) {
+            if (edges[id][i] == 1) {
+                dfs(i, check);
+            }
+        }
+
+        return true;
+    }
+}

--- a/mong3125/DFS/P023_11724.java
+++ b/mong3125/DFS/P023_11724.java
@@ -3,14 +3,12 @@ package CH05_탐색;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.StringTokenizer;
 
 public class P023_11724 {
     static int N, M;
-    static int[][] edges;
-    static int[] cache;
+    static boolean[][] edges;
+    static boolean[] cache;
 
     public static void main(String[] args) throws IOException {
         // 입력
@@ -21,8 +19,8 @@ public class P023_11724 {
         N = Integer.parseInt(st.nextToken());
         M = Integer.parseInt(st.nextToken());
 
-        edges = new int[N + 1][N + 1];
-        cache = new int[N + 1];
+        edges = new boolean[N + 1][N + 1];
+        cache = new boolean[N + 1];
 
         // 엣지 입력
         for (int i = 0; i < M; i++) {
@@ -31,13 +29,13 @@ public class P023_11724 {
             int b = Integer.parseInt(st.nextToken());
 
             // 양방향 입력
-            edges[a][b] = 1;
-            edges[b][a] = 1;
+            edges[a][b] = true;
+            edges[b][a] = true;
         }
 
         int count = 0;
         for (int i = 1; i <= N; i++) {
-            if (dfs(i, i)) {
+            if (dfs(i)) {
                 count++;
             }
         }
@@ -47,14 +45,14 @@ public class P023_11724 {
         br.close();
     }
 
-    public static boolean dfs(int id, int check) {
-        if (cache[id] != 0) return false;
+    public static boolean dfs(int id) {
+        if (cache[id]) return false;
 
-        cache[id] = check;
+        cache[id] = true;
 
         for (int i = 1; i <= N; i++) {
-            if (edges[id][i] == 1) {
-                dfs(i, check);
+            if (edges[id][i]) {
+                dfs(i);
             }
         }
 


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[연결 요소의 개수](https://www.acmicpc.net/problem/11724)

## ✔️ 소요된 시간
<!-- 문제를 해결하는데 소요된 시간을 적어주세요. -->
30분정도 걸렸습니다.

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->

### 문제 설명
노드와 엣지를 입력으로 받습니다.
이 때 우리는 연결 요소의 개수를 세야하는데 연결 요소가 뭔지 몰라서 연결 요소부터 알아보겠습니다.

예를 들어서 설명을 하자면 노드는 섬, 엣지는 다리라고 생각해보겠습니다. 그 때 연결되어있는 덩어리들이 연결 요소입니다.
예제 1번 같은 경우는
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/c7180063-e9eb-4cc9-8071-3d75efbdfa10)
(1,2,5),(3,4) 이렇게 두 덩어리로 이동할 수 있습니다.

그렇다면 떨어저있는 덩어리 개수를 세는게 문제가 제시한 목표라고 볼 수 있죠.

예제 2번은 덩어리가 하나입니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/72ef950e-6bfe-4db7-87d1-b2406d914b61)

### 해결과정
#### 1. 입력을 어떻게 받아야 할까??
처음에는 Node라는 클래스를 만들어서 해결하려고 했습니다. 연결리스트 형식으로 구현을 한 뒤에 DFS 방식으로 풀려고 했어요.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/0c1859ff-a86b-45d4-876e-e5ce08325c76)

하지만 엣지를 연결하는데 시간이 너무 오래 소요가 되었습니다. 왜냐면 노드로 이뤄진 객체 배열을 선언하고 객체 배열 안에서 객체를 찾아서 엣지에 넣어줘야 하기 때문이죠.

뭔말인고 하니 위 사진에서 edges에 추가하려고 하면 새로 생성해서 추가하는게 아니고 기존에 생성된 배열에서 객체를 꺼내와서 넣어줘야합니다. 메모리 오버헤드도 생기고 과정자체가 매끄럽지 못합니다.

그래서 새로운 방법으로 엣지가 연결되어있는지 아닌지 true false로 나타내주는 다음과 같은 배열로 해결했습니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/1f678e21-ff69-4e80-afc8-71077a7e294f)
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/02f2a843-8eb7-428e-a9db-957da95cf154)
(방향이 상관없는 그래프라서 양방향으로 설정해줬습니다)

이러면 입력이 훨씬 간편해지죠.

#### 2. DFS 알고리즘 적용
이제 입력을 다 받아왔으니 문제를 해결해봅시다.
DFS는 아래와 같이 탐색하는 방법입니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/a80bcc59-697b-4e4b-b90e-4752420a94e7)

이렇게 노드에 연결되어있는 엣지를 건너 노드들을 더 깊게 탐색합니다.

이 방법은 for문과 재귀함수로 구현할 수 있습니다.
for문이 먼저 돌기전에 재귀함수로 깊게 깊게 들어가죠 하나의 재귀함수가 다 끝이나면 즉, 깊게 갈 수 있는 곳까지 가서 막혀서 끝이나면 for문에 의해서 다음번째 dfs함수가 실행됩니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/7db5cb6e-2f1f-4e67-b10c-cc24c8f42533)

그럼 이제 dfs로 탐색을 하면서 영역 표시를 해주겠습니다. 이를 저는 cache라는 배열을 통해서 구현을 했는데요.

처음에 보여드린 예제 사진1을 보시면서 설명을 들어주세요. 다음에는 그림도 그려보도록 하겠습니다.

cache는 이전에 방문한적이 있는지 여부를 나타내는 배열입니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/b02ad48b-5f16-4833-af98-ec5327af4bf8)

1. 우선 1을 가면 cache[1]에true로 표시를 해줍니다. 
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/cfe1f6eb-18ea-42d9-a976-8f6fe053d81d)
그 다음에 1의 첫번째 엣지를 건너 2를 방문하게 되면 cache[2]에도 true로 표기를 해주고 2의 첫번째 엣지인 5를 방문하면 cache[5]에도 true로 표기를 해줍니다. 이후 5의 엣지를 방문하면 1을 만나게 되는데 이 노드는 cache를 보니 true로 적혀있습니다. 멈추죠. 그 다음 2의 다음 엣지인 1을 방문합니다. 마찬가지로 true죠 멈춥니다. 1의 다음 엣지인 2도 마찬가지입니다. 이 과정에서 엣지를 통해 갈 수 있는 모든 곳을 다 둘러보게 됩니다.
2. 그 다음에 2를 탐색합니다 cache[2]를 보니 true입니다. 바로 멈춥니다.
3. 그 다음엔 3을 탐색하는데 cache[3]을 보니 false입니다. 탐색을 시작해야겠군요. 1번처럼 과정을 수행합니다. 그 결과로 cache[4]에도 숫자가 적혀집니다.
4. 4를 탐색합니다. cache가 true입니다. 멈춥니다.
5. 5를 탐색합니다. cache가 true입니다. 멈춥니다.

위 과정을 보다보면 시작할 때 멈추면 연결 요소가 새롭게 추가되지 않고 시작할 때 멈추지 않으면 즉 cache에 0이 저장되어있다면 연결 요소가 추가됨을 알 수 있습니다. 이를 통해서 연결 요소를 쉽게 샐 수 있겠네요. 구현해봅시다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/c8c75bd2-157f-4d21-9efe-827b758d1645)


이렇게 되면 이제 true를 반환할 때만 개수에 추가를 해주면 되겠습니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/d517be4a-eaed-4398-af29-c54dc66d42ce)

이제 count를 출력해주기만 하면 문제가 해결됩니다.


## 📚 새롭게 알게된 내용
<!-- 새롭게 알게된 내용이 있다면 작성 해주시고 출처를 남겨주세요. -->
이전에 배웠던 내용인데 사실 오랜만에 알고리즘을 잡아서 기억을 더듬어 가며 이랬었지 저랬었지 하는게 컸습니다.

같이 공부를 하려고 하니 마크업 문법을 좀 공부해야겠네요. 보기 불편하게 적어서 죄송합니다. 다음부터는 따로 수도코드만으로 쉽게쉽게 설명하려고 노력해볼게요 😢
