### PR TITLE
5-YIM2UL2ET

### DIFF
--- a/YIM2UL2ET/README.md
+++ b/YIM2UL2ET/README.md
@@ -4,5 +4,6 @@
 |:----:|:---------:|:----:|:-----:|:----:|
 | 1차시 | 2024.02.12 |  그리디  | [BOJ 18310](https://www.acmicpc.net/problem/18310)  | [BOJ 18310 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/3) |
 | 2차시 | 2024.02.15 |  그리디  | [BOJ 1263](https://www.acmicpc.net/problem/1263)  | [BOJ 1449 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/7) |
-| 3차시 | 2024.02.18 |  자료구조  | [BOJ 2504](https://www.acmicpc.net/problem/2504)  | [BOJ 2504 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/9) |
+| 3차시 | 2024.02.18 |  스택  | [BOJ 2504](https://www.acmicpc.net/problem/2504)  | [BOJ 2504 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/9) |
+| 4차시 | 2024.02.21 |  덱  | [BOJ 1021](https://www.acmicpc.net/problem/1021)  | [BOJ 1021 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/12) |
 ---

--- a/YIM2UL2ET/README.md
+++ b/YIM2UL2ET/README.md
@@ -6,4 +6,5 @@
 | 2차시 | 2024.02.15 |  그리디  | [BOJ 1263](https://www.acmicpc.net/problem/1263)  | [BOJ 1449 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/7) |
 | 3차시 | 2024.02.18 |  스택  | [BOJ 2504](https://www.acmicpc.net/problem/2504)  | [BOJ 2504 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/9) |
 | 4차시 | 2024.02.21 |  덱  | [BOJ 1021](https://www.acmicpc.net/problem/1021)  | [BOJ 1021 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/12) |
+| 5차시 | 2024.02.21 |  큐  | [BOJ 1158](https://www.acmicpc.net/problem/1158)  | [BOJ 1158 풀이](https://github.com/AlgoLeadMe/AlgoLeadMe-7/pull/16) |
 ---

--- a/YIM2UL2ET/덱/4차시 - BOJ 1021.cpp
+++ b/YIM2UL2ET/덱/4차시 - BOJ 1021.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <algorithm>
+#include <deque>
+
+int main(void)
+{
+    int n, m, k, idx, result;
+    std::deque <int> dq;
+
+    std::cin >> n >> m;
+    for (int i = 0; i < n;) {
+        dq.push_back(++i);
+    }
+
+    result = 0;
+    for (int i = 0; i < m; i++) {
+        std::cin >> k;
+
+        std::deque <int> :: iterator iter;
+        iter = std::find(dq.begin(), dq.end(), k);
+        idx = std::distance(dq.begin(), iter);
+
+        if (idx < dq.size() - idx) {
+            result += idx;
+            for (int j = 0; j < idx; j++) {
+                int temp = dq.front();
+                dq.pop_front();
+                dq.push_back(temp);
+            }
+        }
+        else {
+            result += dq.size() - idx;
+            for (int j = 0; j < dq.size() - idx; j++) {
+                int temp = dq.back();
+                dq.pop_back();
+                dq.push_front(temp);
+            }
+        }
+
+        dq.pop_front();
+    }
+    
+    std::cout << result;
+    return 0;   
+}

--- a/YIM2UL2ET/큐/5차시 - BOJ 1158.cpp
+++ b/YIM2UL2ET/큐/5차시 - BOJ 1158.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <vector>
+
+int main(void)
+{
+    int size, k, idx = 0;
+    std::vector <int> v;
+
+    std::cin >> size >> k;
+    for (int i = 0; i < size;) v.push_back(++i);
+
+    std::cout << "<";
+    while(true) {
+        idx = (idx + k - 1) % size--;
+        std::cout << v[idx];
+        v.erase(v.begin() + idx);
+
+        if (size > 0) std::cout << ", ";
+        else break;
+    }
+    std::cout << ">";
+    
+    return 0;
+}


### PR DESCRIPTION
## 🔗 문제 링크
[BOJ 1158 - 요세푸스 문제](https://www.acmicpc.net/problem/1158)

## ✔️ 소요된 시간
30m? (전날 풀었던 거라 자세히 기억이 안 남)

## ✨ 수도 코드

### 1. 문제 설명
이 문제는 원형 배열의 크기 `n`과, 이동 칸수 `k`를 입력 받아서 배열의 첫번째 칸부터 `k`칸씩 이동하여 원소를 출력 및 제거해나가는 문제입니다.

### 2. 문제 해석
저번 문제와 거의 비슷한 문제입니다. 출력 방식만 조금 조정해주면 될 것 같습니다.
(지난 PR을 보고 왔다는 가정 하에 간단히 설명하겠습니다.)

#### 1. 출력 방식
예제의 출력 방식을 예로 들어 봅시다. `<3, 6, 2, 7, 5, 1, 4>` 로 되어 있습니다.

먼저 `"<"`을 출력을 해주어야겠지요.
그 후엔 k번째 요소를 출력 후 `", "`을 출력하는 것을 반복하면 `"<3, 6, 2, ...`가 되겠지요.

하지만 마지막 `">"`가 출력 되는 곳까지 간다면 `"<3, 6, 2, 7, 5, 1, 4, >"`로 출력이 되고 말겠지요. 
따라서 마지막은 예외 처리를 해줘야 합니다. 
`4` 이후에 더 이상 나올 요소가 없으므로 배열의 크기는 `0`이 되었을 것이므로 배열의 사이즈가 `0`이면 종료하면 되겠지요.

그 후엔 `">"`을 출력해주면 코드는 다음과 같이 짤 수 있습니다.

```cpp
std::cout << "<";
    while(true) {
        // 다음 k번째 요소로 이동

        if (size > 0) std::cout << ", ";
        else break;
    }
    std::cout << ">";
```

#### 2. 이동 방식
이 문제는 이동하는 방식이 두 가지 있습니다.
1. `index` 라는 변수를 만들어 이동 시킨다.
2. 원형 배열을 `queue`로 만들어 `pop`과 `push`를 이용하여 이동시킨다.

그 후 `k`번째 사람을 제거하면 1번 방식이나 2번 방식이나 `k+1`번째로 이동합니다.
(인덱스는 그대로인데 사이즈가 줄었기 때문)
따라서 이후에 `k-1`번 이동하면 그 다음 `k`번째로 갈 수 있습니다. 
이는 초기에 `index`를 0으로 초기화 하면 처음부터 같게 갈 수 있습니다.

이동 후엔 출력을 한 후 출력했던 요소를 없애주면 됩니다.

1번 방식의 경우 `index`에 있는 배열의 요소를 출력 후 제거해주면 되고,
2번 방식의 경우 `front`에 있는 것이 `k`번째 요소이므로 맨 앞의 요소를 출력하고 `pop`해주면 되겠지요.

코드로 적으면 다음과 같습니다.

```cpp
// 1번 방식
index = (index + k - 1) % vector.size(); // 이동
std::cout << vector[index];  // 출력
vector.erase(vector.begin() + index);  // 제거
```

```cpp
// 2번 방식
for (int i = 1; i < k; i++) {  // 이동
    int temp = queue.front();
    queue.pop();
    queue.push(temp);
}
std::cout << queue.front();  // 출력
queue.pop();  // 제거
```

이제 출력 방식과 이동 방식을 토대로 수도코드를 짜봅시다.

#### 3. 수도코드
1번 방식이나 2번 방식은 자잘하게 다르지만 큰 틀은 똑같습니다.

```
int형 변수 n, k 선언;
배열 선언;

n, k 입력;
배열의 요소를 1~n까지 초기화;

"<" 출력;
while(true) {
    k번째 요소로 이동;
    k번째 요소 출력;
    k번째 요소 제거;

    if (배열의 크기 > 0) ", " 출력;
    else break;
}
">" 출력;

프로그램 종료;
```

#### 4. 최종코드
```cpp
// ver.1
#include <iostream>
#include <vector>

int main(void)
{
    int size, k, idx = 0;
    std::vector <int> v;

    std::cin >> size >> k;
    for (int i = 0; i < size;) v.push_back(++i);

    std::cout << "<";
    while(true) {
        idx = (idx + k - 1) % size--;
        std::cout << v[idx];
        v.erase(v.begin() + idx);

        if (size > 0) std::cout << ", ";
        else break;
    }
    std::cout << ">";
    
    return 0;
}
```

```cpp
// ver.2
#include <iostream>
#include <queue>

int main(void)
{
    int n, k;
    std::queue <int> v;

    std::cin >> n >> k;
    for (int i = 0; i < n;) v.push(++i);

    std::cout << "<";
    while(true) {
        for (int i = 1; i < k; i++) {
            int temp = v.front();
            v.pop();
            v.push(temp);
        }
        std::cout << v.front();
        v.pop();

        if (v.size() > 0) std::cout << ", ";
        else break;
    }
    std::cout << ">";
    
    return 0;
}
```

#### 5. 차이점
| | ver.1 | ver.2 |
|:---------:|:-----------:|:---------:|
| 배열 | `vector` 사용 | `queue` 사용 |
| `k`번째 요소 | `vector[index]` | `queue.front()` |
| 소요시간 | 상대적으로 짧음 | 상대적으로 긺 |

## 📚 새롭게 알게된 내용
오늘은 좀 많이 쉬운걸로 가져왔습니다. (오늘 풀려고 했던 문제들이 단 한 문제도 풀리지 않았기 때문이죠..)
적다 보니 저번 문제의 하위 호환 버전인 것 같네요.. 다음 문제는 미리 어려운걸 좀 풀어서 새로운 걸로 가져오겠습니다.