### PR TITLE
5-mong3125

### DIFF
--- a/mong3125/수학/BOJ10986.java
+++ b/mong3125/수학/BOJ10986.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ10986 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        int[] remainders = new int[N + 1];  // 부분 합을 M으로 나눈 리스트
+        int[] remainders_count = new int[M];     // 나머지 개수
+        for (int i = 1; i <= N; i++) {
+            remainders[i] = (remainders[i - 1] + Integer.parseInt(st.nextToken())) % M;
+            remainders_count[remainders[i]] += 1;
+        }
+
+        long count = 0;
+        for (int i = 0; i < M; i++) {
+            count += (long) remainders_count[i] * (remainders_count[i] - 1) / 2;   // 조합
+        }
+
+        count += remainders_count[0];  // 나머지가 0일때 (i = j 일때)
+
+        System.out.println(count);
+    }
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[백준 10986 - 나머지 합](https://www.acmicpc.net/problem/10986)

## ✔️ 소요된 시간
아이디어랑 코드 구현은 빨랐는데 계속 오류가 터져서 알고보니 오버플로우 문제였습니다.
2시간은 삽질했네요.

## ✨ 수도 코드
<!-- 내가 작성한 코드를 모르는 사람이 봐도 이해할 수 있도록 글로 쉽게 풀어서 설명해주세요. -->
<!-- 알고리즘에 대한 지식이 전혀 없는 사람이 봐도 이해할 수 있도록 작성해주세요. 시각자료를 이용하면 더 좋습니다. -->
### 구간 합...?

구간 합이라는 개념을 알고 있다면 쉽게 풀 수 있는 문제입니다.

'구간 합 배열'은 i 번째 요소가 0부터 i번째까지의 합으로 이루어진 배열입니다.

예를 들어, 숫자 배열이 `{1, 2, 5, 8, 4, 7}` 이렇게 있다고 가정하면 구간 합 배열은 `{1, 3, 8, 16, 20, 27}`이 됩니다.

이 때 만약 제가 인덱스가 2부터 4까지의 합을 구하고 싶다면 구간 합 배열의 인덱스 4의 요소 `20`에서 인덱스 1의 요소 `3`을 빼면 `17`이라는 결과를 바로 얻을 수 있습니다. 실제로 `5 + 8 + 4`의 결과는 `17`이죠

이 방법의 장점은 구간 합을 **O(n)의 시간복잡도에서 O(1)로** 줄일 수 있습니다.

### 문제의 메인 목표

문제에서 제시하는 목표는 연속된 부분의 합이 어떤 수 M으로 나누어 떨어지는 구간

**즉, 구간 합 배열에서 어떤 요소 두 개를 빼고(S[j] - S[i-1]) 나머지 연산을 했을때(M으로 나눴을 때) 0이 나오는 경우의 수(i,j) 입니다.**

이는 모듈러 정리에 의해 S[j] % M = S[i -1] % M를 만족하는 i, j를 뽑는 경우의 수입니다.

⇒ 구간 합의 나머지가 같은 인덱스 두 개를 뽑는 조합

1️⃣ 우선 구간 합 배열에 나머지 연산을 적용한 배열을 구해보겠습니다.

- 이전 나머지와 다음 입력(원소)를 더한 후, 나머지 연산을 하면 같은 결과가 나옵니다.

구간 합이라는 개념을 알고 있다면 쉽게 풀 수 있는 문제입니다.

'구간 합 배열'은 i 번째 요소가 0부터 i번째까지의 합으로 이루어진 배열입니다.

예를 들어, 숫자 배열이 `{1, 2, 5, 8, 4, 7}` 이렇게 있다고 가정하면 구간 합 배열은 `{1, 3, 8, 16, 20, 27}`이 됩니다.

이 때 만약 제가 인덱스가 2부터 4까지의 합을 구하고 싶다면 구간 합 배열의 인덱스 4의 요소 `20`에서 인덱스 1의 요소 `3`을 빼면 `17`이라는 결과를 바로 얻을 수 있습니다. 실제로 `5 + 8 + 4`의 결과는 `17`이죠

이 방법의 장점은 구간 합을 **O(n)의 시간복잡도에서 O(1)로** 줄일 수 있습니다.

### 구간 합의 나머지는?
구간 합의 나머지를 구하는 것은 이제 쉬워졌습니다. 그냥 합에서 나머지를 구하면 되니깐요.

하지만 매번 숫자를 입력받을때 마다 나머지를 구해서 저장을 하고 이전 값의 나머지와 이후 값을 더한 뒤에 나머지 연산을 해도 같은 결과를 얻을 수 있습니다. 아래 그림처럼요!
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/8055082b-3e0c-4bf1-9aae-cb67c0bf9822)

2️⃣ 이제 나머지 연산을 한 원소들을 빼는 결과가 0이 나와야 되므로 나머지가 같은 것의 개수를 세어줍니다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/20596943-1a12-4f02-bf6b-4e9fd62e7434)

3️⃣ 조합으로 개수를 세어봅시다. 
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/b1e1e7be-d322-41e5-8541-46c6e528b24f)

4️⃣ 나머지가 0인 경우는 자기 자신 하나로도 조건을 충족하므로(i==j 인 경우) 세어줍시다.
![image](https://github.com/AlgoLeadMe/AlgoLeadMe-7/assets/84318115/3a6610df-df47-4255-a0f2-7180e0284cca)

## 📚 새롭게 알게된 내용
- 구간 합의 나머지를 구할 때, 이전 나머지에서 새로운 수를 더하고 나머지 연산함으로써 메모리를 절약할 수 있음을 알게 되었습니다.
    - int 자료형으로 하니까 오버플로우가 발생해서 틀렸었습니다.
- 조합을 구하려고 할 때, 나머지보다 곱셈이 먼저 있다보니 int자료형에서 표현할 수 있는 범위를 넘어서 이를 long 타입으로 구현했습니다.
