### PR TITLE
8-mong3125

### DIFF
--- a/mong3125/BFS/BOJ1260_DFS와BFS프로그램.java
+++ b/mong3125/BFS/BOJ1260_DFS와BFS프로그램.java
@@ -1,0 +1,84 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BOJ1260_DFS와BFS프로그램 {
+
+    static ArrayList<Integer>[] edges;
+    static boolean[] visited;
+    static StringBuilder answer = new StringBuilder();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());   // 노드 수
+        int m = Integer.parseInt(st.nextToken());   // 간선 수
+        int v = Integer.parseInt(st.nextToken());   // 출발 노드
+
+        edges = new ArrayList[n + 1];   // 간선 배열
+        for (int i = 0; i < n + 1; i++) {
+            edges[i] = new ArrayList<>();
+        }
+
+        // 간선 연결
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            edges[a].add(b);
+            edges[b].add(a);
+        }
+
+        for (int i = 0; i < n + 1; i++) {
+            Collections.sort(edges[i]);
+        }
+
+        visited = new boolean[n + 1];       // 방문 여부 배열
+        dfs(v);
+        answer.append('\n');
+
+        visited = new boolean[n + 1];
+        bfs(v);
+        answer.append('\n');
+
+        System.out.print(answer);
+    }
+
+    public static void dfs(int now) {
+        answer.append(now);
+        answer.append(' ');
+
+        visited[now] = true;
+
+        for (int next : edges[now]) {
+            if (!visited[next]) {
+                dfs(next);
+            }
+        }
+    }
+
+    public static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+
+        // 시작 노드 삽입하기
+        queue.add(start);
+        visited[start] = true;
+
+        // 큐가 빌때까지 반복
+        while (!queue.isEmpty()) {
+            int now = queue.poll();
+            answer.append(now);
+            answer.append(' ');
+
+            // now에 연결된 node들을 queue에 삽입한다.
+            for (int next : edges[now]) {
+                if (!visited[next]) {
+                    queue.add(next);
+                    visited[next] = true;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR은 최대한 다른 사람이 알아보기 쉽도록 자세히 써주세요. 특히 수도 코드 부분은 더더욱요...!!-->

## 🔗 문제 링크
<!-- 해결한 문제의 링크를 올려주세요. -->
[DFS와 BFS](https://www.acmicpc.net/problem/1260)

## ✔️ 소요된 시간
2시간

이것도 문제를 다 해결했는데 실수 하나 때문에 오래걸렸습니다.
꼼꼼함이 부족해서 계속 시간이 오래걸리네요..

## ✨ 수도 코드
엣지 리스트를 이차원 배열로 저장합니다. (배열 x 리스트로 구현해서 노드는 배열로 들어오는 엣지는 리스트로 append하는 방식으로 구현했어요)

DFS와 BFS를 구현하면 되는 간단한 문제입니다.
DFS는 재귀로 구현을 했고 BFS는 queue를 이용해서 구현했습니다.
```
dfs() {
    결과에 추가
    방문 체크
    현재 노드의 연결 노드 중 방문하지 않은 노드로 DFS 실행하기
}

bfs() {
    큐 자료구조에 시작 노드 삽입
    방문 체크
    while (큐가 빌때까지) {
        큐에서 노드 데이터 가져오고 삭제
        가져온 노드를 결과에 추가
        현재 노드의 연결 노드중에서 방문하지 않은 노드를 큐에 삽입하고 방문 체크
    }
}
```

## 📚 새롭게 알게된 내용
* DFS나 BFS로 탐색을 할 때, 정렬된 상태를 기준으로 탐색을 하더군요. 어디서든 정렬을 잘 배워야 될 것 같습니다.
* java의 큐는 LinkedList 자료형을 사용한다.
* 숫자를 n까지 사용하면 n+1의 크기를 가진 배열을 선언하게된다. 이때 정렬같이 전체 필드를 작업할때 for문에서 i<n+1로 설정하는 것을 잊지말자!